### PR TITLE
Command Line Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ Usage: fs|filestation [options] <method>
   Options:
 
     -h, --help               output usage information
-    -c, --config <path>      DSM Login Config file. defaults to ~/.syno/auth.yaml
-    -u, --url <url>          DSM Uri - Default : (http://admin:password@localhost:5001)
+    -c, --config <path>      DSM configuration file. Default to ~/.syno/auth.yaml
+    -u, --url <url>          DSM URL. Default to https://admin:password@localhost:5001
     -p, --payload <payload>  JSON Payload
-    -P, --pretty             Pretty print JSON output
+    -P, --pretty             Prettyprint JSON Output
     -d, --debug              Enabling Debugging Output
 
   Examples:
@@ -86,10 +86,10 @@ Usage: dl|downloadstation [options] <method>
   Options:
 
     -h, --help               output usage information
-    -c, --config <path>      DSM Login Config file. defaults to ~/.syno/auth.yaml
-    -u, --url <url>          DSM Uri - Default : (http://admin:password@localhost:5001)
+    -c, --config <path>      DSM configuration file. Default to ~/.syno/auth.yaml
+    -u, --url <url>          DSM URL. Default to https://admin:password@localhost:5001
     -p, --payload <payload>  JSON Payload
-    -P, --pretty             Pretty print JSON output
+    -P, --pretty             Prettyprint JSON Output
     -d, --debug              Enabling Debugging Output
 
   Examples:
@@ -99,18 +99,31 @@ Usage: dl|downloadstation [options] <method>
     $ syno dl getTasksInfo --pretty --payload '{"id":"task_id"}'
 ```
 
+## Examples
+
+### Without a configuration file
+
+```bash
+$ syno fs getFileStationInfo -u https://admin:synology@demo.synology.com:5001 -P
+```
+
+### With a configuration file
 
 ```yaml
 
 # Example config file, by default it should be located at:
-# ~/.syno/auth.conf
+# ~/.syno/config.conf
 
-auth:
+url:
   protocol: http
   host: localhost
   port: 5001
   account: admin
   passwd: password
+```
+
+```bash
+$ syno fs getFileStationInfo
 ```
 
 ## Syno JS library

--- a/README.md
+++ b/README.md
@@ -17,15 +17,97 @@ Just install the module using npm.
 npm install syno
 ```
 
-If you want to save it as a dependecy, just add the `--save` option.
+If you want to save it as a dependency, just add the `--save` option.
 
 ```
 npm install syno --save
 ```
 
+If you want to install with the CLI executable, just add the `--global` option.
+
+```
+npm install syno --global
+```
+
 # Usage
 
-## Syno
+## Syno CLI executable
+
+```
+Usage: syno [options]
+
+  Synology Rest API Command Line
+
+  Options:
+
+    -h, --help           output usage information
+    -V, --version        output the version number
+
+  Commands:
+
+    fs|filestation [options] <method>  DSM File Station API
+    dl|downloadstation [options] <method>  DSM Download Station API
+
+  Examples:
+
+    $ syno fs getFileStationInfo
+    $ syno dl getDownloadStationInfo
+```
+
+```
+Usage: fs|filestation [options] <method>
+
+  DSM File Station API
+
+  Options:
+
+    -h, --help               output usage information
+    -c, --config <path>      DSM Login Config file. defaults to ~/.syno/auth.yaml
+    -u, --url <url>          DSM Uri - Default : (http://admin:password@localhost:5001)
+    -p, --payload <payload>  JSON Payload
+    -P, --pretty             Pretty print JSON output
+
+  Examples:
+
+    $ syno fs listSharedFolders
+    $ syno fs listFiles --pretty --payload '{"folder_path":"/path/to/folder"}'
+```
+
+```
+Usage: dl|downloadstation [options] <method>
+
+  DSM Download Station API
+
+  Options:
+
+    -h, --help               output usage information
+    -c, --config <path>      DSM Login Config file. defaults to ~/.syno/auth.yaml
+    -u, --url <url>          DSM Uri - Default : (http://admin:password@localhost:5001)
+    -p, --payload <payload>  JSON Payload
+    -P, --pretty             Pretty print JSON output
+
+  Examples:
+
+    $ syno dl listTasks
+    $ syno dl listTasks --payload '{"limit":1}'
+    $ syno dl getTasksInfo --pretty --payload '{"id":"task_id"}'
+```
+
+
+```yaml
+
+# Example config file, by default it should be located at:
+# ~/.syno/auth.conf
+
+auth:
+  protocol: http
+  host: localhost
+  port: 5001
+  account: admin
+  passwd: password
+```
+
+## Syno JS library
 
 ```js
 var Syno = require('syno');
@@ -515,7 +597,7 @@ given, binary content in ZIP format which they are compressed to is responded.
 **Required params** : path, stream
 
 ```js
-syno.fs.dowbload(params, callback);
+syno.fs.download(params, callback);
 ```
 
 **N.B. :** `stream` param must be a Writable Stream

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Usage: fs|filestation [options] <method>
     -u, --url <url>          DSM Uri - Default : (http://admin:password@localhost:5001)
     -p, --payload <payload>  JSON Payload
     -P, --pretty             Pretty print JSON output
+    -d, --debug              Enabling Debugging Output
 
   Examples:
 
@@ -89,6 +90,7 @@ Usage: dl|downloadstation [options] <method>
     -u, --url <url>          DSM Uri - Default : (http://admin:password@localhost:5001)
     -p, --payload <payload>  JSON Payload
     -P, --pretty             Pretty print JSON output
+    -d, --debug              Enabling Debugging Output
 
   Examples:
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ npm install syno --global
 
 ## Syno CLI executable
 
+
 ```
+$ syno --help
 Usage: syno [options]
 
   Synology Rest API Command Line
@@ -55,6 +57,7 @@ Usage: syno [options]
 ```
 
 ```
+$ syno fs --help
 Usage: fs|filestation [options] <method>
 
   DSM File Station API
@@ -74,6 +77,7 @@ Usage: fs|filestation [options] <method>
 ```
 
 ```
+$ syno ds --help
 Usage: dl|downloadstation [options] <method>
 
   DSM Download Station API

--- a/bin/syno.js
+++ b/bin/syno.js
@@ -1,6 +1,4 @@
-var CONFIG_DIR, CONFIG_FILE, DEBUG, Syno, execute, fs, nconf, os, path, program, syno, url, url_resolved, yaml;
-
-DEBUG = true;
+var CONFIG_DIR, CONFIG_FILE, Syno, execute, fs, nconf, os, path, program, syno, url, url_resolved, yaml;
 
 CONFIG_DIR = '.syno';
 
@@ -24,13 +22,13 @@ os = require('os');
 
 execute = function(api, cmd, options) {
   var exception, payload;
-  if (DEBUG) {
+  if (program.debug) {
     console.log("[DEBUG] : Method name : %s", cmd);
   }
-  if (options.payload && DEBUG) {
+  if (options.payload && program.debug) {
     console.log("[DEBUG] : Method payload : %s", options.payload);
   }
-  if (options.pretty && DEBUG) {
+  if (options.pretty && program.debug) {
     console.log('[DEBUG] : Prettify output detected');
   }
   try {
@@ -56,7 +54,7 @@ execute = function(api, cmd, options) {
   });
 };
 
-program.version('1.0.1').description('Synology Rest API Command Line').option('-c, --config <path>', "DSM Login Config file. defaults to ~/" + CONFIG_DIR + "/" + CONFIG_FILE).option('-u, --url <url>', 'DSM Uri - Default : (http://admin:password@localhost:5001)').on('--help', function() {
+program.version('1.0.1').description('Synology Rest API Command Line').option('-c, --config <path>', "DSM Login Config file. defaults to ~/" + CONFIG_DIR + "/" + CONFIG_FILE).option('-u, --url <url>', 'DSM Uri - Default : (http://admin:password@localhost:5001)').option('-d, --debug', 'Enabling Debugging Output').on('--help', function() {
   console.log('  Commands:');
   console.log('');
   console.log('    fs|filestation [options] <method>  DSM File Station API');
@@ -89,7 +87,7 @@ if (program.args.length === 0) {
 nconf.argv.env;
 
 if (program.url) {
-  if (DEBUG) {
+  if (program.debug) {
     console.log("[DEBUG] : Url detected : %s.", program.url);
   }
   url_resolved = url.parse(program.url);
@@ -103,7 +101,7 @@ if (program.url) {
     }
   });
 } else if (program.config) {
-  if (DEBUG) {
+  if (program.debug) {
     console.log("[DEBUG] : Load config file : %s.", program.config);
   }
   if (fs.existsSync(program.config)) {
@@ -123,7 +121,7 @@ if (program.url) {
     process.exit(1);
   }
 } else {
-  if (DEBUG) {
+  if (program.debug) {
     console.log("[DEBUG] : Load default config file : ~/" + CONFIG_DIR + "/auth.yaml.");
   }
   nconf.file({
@@ -150,7 +148,7 @@ nconf.defaults({
 });
 
 if (!fs.existsSync(path.homedir() + ("/" + CONFIG_DIR))) {
-  if (DEBUG) {
+  if (program.debug) {
     console.log("[DEBUG] : %s doesn't exist", path.homedir() + ("/" + CONFIG_DIR));
   }
   fs.mkdir(path.homedir() + ("/" + CONFIG_DIR), function(err) {
@@ -162,7 +160,7 @@ if (!fs.existsSync(path.homedir() + ("/" + CONFIG_DIR))) {
       nconf.set('auth:port', 5001);
       nconf.set('auth:account', 'admin');
       nconf.set('auth:passwd', 'password');
-      if (DEBUG) {
+      if (program.debug) {
         console.log("[DEBUG] : Save default config file to : %s", path.homedir() + ("/" + CONFIG_DIR));
       }
       return nconf.save();
@@ -178,20 +176,20 @@ syno = new Syno({
   passwd: nconf.get('auth:passwd')
 });
 
-program.command('fs <method>').alias('filestation').description('DSM File Station API').option('-c, --config <path>', "DSM Login Config file. defaults to ~/" + CONFIG_DIR + "/" + CONFIG_FILE).option('-u, --url <url>', 'DSM Uri - Default : (http://admin:password@localhost:5001)').option("-p, --payload <payload>", "JSON Payload").option('-P, --pretty', 'Pretty print JSON output').on('--help', function() {
+program.command('fs <method>').alias('filestation').description('DSM File Station API').option('-c, --config <path>', "DSM Login Config file. defaults to ~/" + CONFIG_DIR + "/" + CONFIG_FILE).option('-u, --url <url>', 'DSM Uri - Default : (http://admin:password@localhost:5001)').option("-p, --payload <payload>", "JSON Payload").option('-P, --pretty', 'Pretty print JSON output').option('-d, --debug', 'Enabling Debugging Output').on('--help', function() {
   console.log('  Examples:');
   console.log('');
   console.log('    $ syno fs listSharedFolders');
   console.log('    $ syno fs listFiles --pretty --payload \'{"folder_path":"/path/to/folder"}\'');
   return console.log('');
 }).action(function(cmd, options) {
-  if (DEBUG) {
+  if (program.debug) {
     console.log("[DEBUG] : DSM File Station API selected");
   }
   return execute('fs', cmd, options);
 });
 
-program.command('dl <method>').alias('downloadstation').description('DSM Download Station API').option('-c, --config <path>', "DSM Login Config file. defaults to ~/" + CONFIG_DIR + "/" + CONFIG_FILE).option('-u, --url <url>', 'DSM Uri - Default : (http://admin:password@localhost:5001)').option("-p, --payload <payload>", "JSON Payload").option('-P, --pretty', 'Pretty print JSON output').on('--help', function() {
+program.command('dl <method>').alias('downloadstation').description('DSM Download Station API').option('-c, --config <path>', "DSM Login Config file. defaults to ~/" + CONFIG_DIR + "/" + CONFIG_FILE).option('-u, --url <url>', 'DSM Uri - Default : (http://admin:password@localhost:5001)').option("-p, --payload <payload>", "JSON Payload").option('-P, --pretty', 'Pretty print JSON output').option('-d, --debug', 'Enabling Debugging Output').on('--help', function() {
   console.log('  Examples:');
   console.log('');
   console.log('    $ syno dl listTasks');
@@ -199,7 +197,7 @@ program.command('dl <method>').alias('downloadstation').description('DSM Downloa
   console.log('    $ syno dl getTasksInfo --pretty --payload \'{"id":"task_id"}\'');
   return console.log('');
 }).action(function(cmd, options) {
-  if (DEBUG) {
+  if (program.debug) {
     console.log("[DEBUG] : DSM Download Station API selected");
   }
   return execute('dl', cmd, options);

--- a/bin/syno.js
+++ b/bin/syno.js
@@ -72,8 +72,18 @@ program.version('1.0.1').description('Synology Rest API Command Line').option('-
 
 program.parse(process.argv);
 
-if (program.args.length === 0 || (program.args.length > 0 && program.args[0] !== 'fs' && program.args[0] !== 'dl')) {
+if (program.args.length === 0) {
   program.help();
+} else if (program.args.length > 0 && program.args[0] !== 'fs' && program.args[0] !== 'dl') {
+  console.log('');
+  console.log("  [ERROR] : " + program.args[0] + " is not a valid command !");
+  console.log('');
+  console.log('  Examples:');
+  console.log('');
+  console.log('    $ syno fs <method> DSM File Station API');
+  console.log('    $ syno dl <method> DSM Download Station API');
+  console.log('');
+  process.exit(1);
 }
 
 nconf.argv.env;
@@ -139,22 +149,26 @@ nconf.defaults({
   }
 });
 
-nconf.save(function(err) {
-  if (err && err.code === "ENOENT") {
-    fs.mkdir(path.homedir() + ("/" + CONFIG_DIR), function(err) {
-      if (err) {
-        return console.log;
-      } else {
-        nconf.set('auth:protocol', 'http');
-        nconf.set('auth:host', 'localhost');
-        nconf.set('auth:port', 5001);
-        nconf.set('auth:account', 'admin');
-        nconf.set('auth:passwd', 'password');
-        return nconf.save();
-      }
-    });
+if (!fs.existsSync(path.homedir() + ("/" + CONFIG_DIR))) {
+  if (DEBUG) {
+    console.log("[DEBUG] : %s doesn't exist", path.homedir() + ("/" + CONFIG_DIR));
   }
-});
+  fs.mkdir(path.homedir() + ("/" + CONFIG_DIR), function(err) {
+    if (err) {
+      return console.log(err);
+    } else {
+      nconf.set('auth:protocol', 'http');
+      nconf.set('auth:host', 'localhost');
+      nconf.set('auth:port', 5001);
+      nconf.set('auth:account', 'admin');
+      nconf.set('auth:passwd', 'password');
+      if (DEBUG) {
+        console.log("[DEBUG] : Save default config file to : %s", path.homedir() + ("/" + CONFIG_DIR));
+      }
+      return nconf.save();
+    }
+  });
+}
 
 syno = new Syno({
   protocol: nconf.get('auth:protocol'),

--- a/bin/syno.js
+++ b/bin/syno.js
@@ -2,7 +2,7 @@ var CONFIG_DIR, CONFIG_FILE, Syno, execute, fs, nconf, os, path, program, syno, 
 
 CONFIG_DIR = '.syno';
 
-CONFIG_FILE = 'auth.yaml';
+CONFIG_FILE = 'config.yaml';
 
 program = require('commander');
 
@@ -55,7 +55,7 @@ execute = function(api, cmd, options) {
   });
 };
 
-program.version('1.0.1').description('Synology Rest API Command Line').option('-c, --config <path>', "DSM Login Config file. defaults to ~/" + CONFIG_DIR + "/" + CONFIG_FILE).option('-u, --url <url>', 'DSM Uri - Default : (http://admin:password@localhost:5001)').option('-d, --debug', 'Enabling Debugging Output').on('--help', function() {
+program.version('1.0.1').description('Synology Rest API Command Line').option('-c, --config <path>', "DSM Configuration file. Default to ~/" + CONFIG_DIR + "/" + CONFIG_FILE).option('-u, --url <url>', 'DSM URL. Default to https://admin:password@localhost:5001').option('-d, --debug', 'Enabling Debugging Output').on('--help', function() {
   console.log('  Commands:');
   console.log('');
   console.log('    fs|filestation [options] <method>  DSM File Station API');
@@ -93,7 +93,7 @@ if (program.url) {
   }
   url_resolved = url.parse(program.url);
   nconf.overrides({
-    auth: {
+    url: {
       protocol: url_resolved.protocol.slice(0, -1),
       host: url_resolved.hostname,
       port: url_resolved.port,
@@ -123,7 +123,7 @@ if (program.url) {
   }
 } else {
   if (program.debug) {
-    console.log("[DEBUG] : Load default config file : ~/" + CONFIG_DIR + "/auth.yaml.");
+    console.log("[DEBUG] : Load default config file : ~/" + CONFIG_DIR + "/" + CONFIG_FILE + ".");
   }
   nconf.file({
     file: path.homedir() + ("/" + CONFIG_DIR + "/" + CONFIG_FILE),
@@ -139,7 +139,7 @@ if (program.url) {
 }
 
 nconf.defaults({
-  auth: {
+  url: {
     protocol: 'http',
     host: 'localhost',
     port: 5001,
@@ -154,30 +154,34 @@ if (!fs.existsSync(path.homedir() + ("/" + CONFIG_DIR))) {
   }
   fs.mkdir(path.homedir() + ("/" + CONFIG_DIR), function(err) {
     if (err) {
-      return console.log(err);
+      return console.log("[ERROR] : %s", err);
     } else {
-      nconf.set('auth:protocol', 'http');
-      nconf.set('auth:host', 'localhost');
-      nconf.set('auth:port', 5001);
-      nconf.set('auth:account', 'admin');
-      nconf.set('auth:passwd', 'password');
+      nconf.set('url:protocol', 'https');
+      nconf.set('url:host', 'localhost');
+      nconf.set('url:port', 5001);
+      nconf.set('url:account', 'admin');
+      nconf.set('url:passwd', 'password');
       if (program.debug) {
-        console.log("[DEBUG] : Save default config file to : %s", path.homedir() + ("/" + CONFIG_DIR));
+        console.log("[DEBUG] : Save default configuration file to : %s", path.homedir() + ("/" + CONFIG_DIR + "/" + CONFIG_FILE));
       }
       return nconf.save();
     }
   });
 }
 
+if (program.debug) {
+  console.log("[DEBUG] : Connection URL : %s://%s:%s@%s:%s", nconf.get('url:protocol'), nconf.get('url:account'), nconf.get('url:passwd'), nconf.get('url:host'), nconf.get('url:port'));
+}
+
 syno = new Syno({
-  protocol: nconf.get('auth:protocol'),
-  host: nconf.get('auth:host'),
-  port: nconf.get('auth:port'),
-  account: nconf.get('auth:account'),
-  passwd: nconf.get('auth:passwd')
+  protocol: nconf.get('url:protocol'),
+  host: nconf.get('url:host'),
+  port: nconf.get('url:port'),
+  account: nconf.get('url:account'),
+  passwd: nconf.get('url:passwd')
 });
 
-program.command('fs <method>').alias('filestation').description('DSM File Station API').option('-c, --config <path>', "DSM Login Config file. defaults to ~/" + CONFIG_DIR + "/" + CONFIG_FILE).option('-u, --url <url>', 'DSM Uri - Default : (http://admin:password@localhost:5001)').option("-p, --payload <payload>", "JSON Payload").option('-P, --pretty', 'Pretty print JSON output').option('-d, --debug', 'Enabling Debugging Output').on('--help', function() {
+program.command('fs <method>').alias('filestation').description('DSM File Station API').option('-c, --config <path>', "DSM configuration file. Default to ~/" + CONFIG_DIR + "/" + CONFIG_FILE).option('-u, --url <url>', 'DSM URL. Default to https://admin:password@localhost:5001').option("-p, --payload <payload>", "JSON Payload").option('-P, --pretty', 'Pretty print JSON output').option('-d, --debug', 'Enabling Debugging Output').on('--help', function() {
   console.log('  Examples:');
   console.log('');
   console.log('    $ syno fs listSharedFolders');
@@ -190,7 +194,7 @@ program.command('fs <method>').alias('filestation').description('DSM File Statio
   return execute('fs', cmd, options);
 });
 
-program.command('dl <method>').alias('downloadstation').description('DSM Download Station API').option('-c, --config <path>', "DSM Login Config file. defaults to ~/" + CONFIG_DIR + "/" + CONFIG_FILE).option('-u, --url <url>', 'DSM Uri - Default : (http://admin:password@localhost:5001)').option("-p, --payload <payload>", "JSON Payload").option('-P, --pretty', 'Pretty print JSON output').option('-d, --debug', 'Enabling Debugging Output').on('--help', function() {
+program.command('dl <method>').alias('downloadstation').description('DSM Download Station API').option('-c, --config <path>', "DSM configuration file. Default to ~/" + CONFIG_DIR + "/" + CONFIG_FILE).option('-u, --url <url>', 'DSM URL. Default to https://admin:password@localhost:5001').option("-p, --payload <payload>", "JSON Payload").option('-P, --pretty', 'Pretty print JSON output').option('-d, --debug', 'Enabling Debugging Output').on('--help', function() {
   console.log('  Examples:');
   console.log('');
   console.log('    $ syno dl listTasks');

--- a/bin/syno.js
+++ b/bin/syno.js
@@ -103,7 +103,7 @@ if (program.url) {
   });
 } else if (program.config) {
   if (program.debug) {
-    console.log("[DEBUG] : Load config file : %s.", program.config);
+    console.log("[DEBUG] : Load config file : %s", program.config);
   }
   if (fs.existsSync(program.config)) {
     nconf.file({
@@ -118,12 +118,32 @@ if (program.url) {
       }
     });
   } else {
-    console.log("[ERROR] : Config file : %s not found.", program.config);
+    console.log("[ERROR] : Config file : %s not found", program.config);
     process.exit(1);
   }
 } else {
+  if (!fs.existsSync(path.homedir() + ("/" + CONFIG_DIR))) {
+    if (program.debug) {
+      console.log("[DEBUG] : %s doesn't exist", path.homedir() + ("/" + CONFIG_DIR));
+    }
+    fs.mkdir(path.homedir() + ("/" + CONFIG_DIR), function(err) {
+      if (err) {
+        return console.log("[ERROR] : %s", err);
+      } else {
+        nconf.set('url:protocol', 'https');
+        nconf.set('url:host', 'localhost');
+        nconf.set('url:port', 5001);
+        nconf.set('url:account', 'admin');
+        nconf.set('url:passwd', 'password');
+        if (program.debug) {
+          console.log("[DEBUG] : Save default configuration file to : %s", path.homedir() + ("/" + CONFIG_DIR + "/" + CONFIG_FILE));
+        }
+        return nconf.save();
+      }
+    });
+  }
   if (program.debug) {
-    console.log("[DEBUG] : Load default config file : ~/" + CONFIG_DIR + "/" + CONFIG_FILE + ".");
+    console.log("[DEBUG] : Load default config file : ~/" + CONFIG_DIR + "/" + CONFIG_FILE);
   }
   nconf.file({
     file: path.homedir() + ("/" + CONFIG_DIR + "/" + CONFIG_FILE),
@@ -148,27 +168,6 @@ nconf.defaults({
   }
 });
 
-if (!fs.existsSync(path.homedir() + ("/" + CONFIG_DIR))) {
-  if (program.debug) {
-    console.log("[DEBUG] : %s doesn't exist", path.homedir() + ("/" + CONFIG_DIR));
-  }
-  fs.mkdir(path.homedir() + ("/" + CONFIG_DIR), function(err) {
-    if (err) {
-      return console.log("[ERROR] : %s", err);
-    } else {
-      nconf.set('url:protocol', 'https');
-      nconf.set('url:host', 'localhost');
-      nconf.set('url:port', 5001);
-      nconf.set('url:account', 'admin');
-      nconf.set('url:passwd', 'password');
-      if (program.debug) {
-        console.log("[DEBUG] : Save default configuration file to : %s", path.homedir() + ("/" + CONFIG_DIR + "/" + CONFIG_FILE));
-      }
-      return nconf.save();
-    }
-  });
-}
-
 if (program.debug) {
   console.log("[DEBUG] : Connection URL : %s://%s:%s@%s:%s", nconf.get('url:protocol'), nconf.get('url:account'), nconf.get('url:passwd'), nconf.get('url:host'), nconf.get('url:port'));
 }
@@ -181,7 +180,7 @@ syno = new Syno({
   passwd: nconf.get('url:passwd')
 });
 
-program.command('fs <method>').alias('filestation').description('DSM File Station API').option('-c, --config <path>', "DSM configuration file. Default to ~/" + CONFIG_DIR + "/" + CONFIG_FILE).option('-u, --url <url>', 'DSM URL. Default to https://admin:password@localhost:5001').option("-p, --payload <payload>", "JSON Payload").option('-P, --pretty', 'Pretty print JSON output').option('-d, --debug', 'Enabling Debugging Output').on('--help', function() {
+program.command('fs <method>').alias('filestation').description('DSM File Station API').option('-c, --config <path>', "DSM configuration file. Default to ~/" + CONFIG_DIR + "/" + CONFIG_FILE).option('-u, --url <url>', 'DSM URL. Default to https://admin:password@localhost:5001').option("-p, --payload <payload>", "JSON Payload").option('-P, --pretty', 'Prettyprint JSON Output').option('-d, --debug', 'Enabling Debugging Output').on('--help', function() {
   console.log('  Examples:');
   console.log('');
   console.log('    $ syno fs listSharedFolders');
@@ -194,7 +193,7 @@ program.command('fs <method>').alias('filestation').description('DSM File Statio
   return execute('fs', cmd, options);
 });
 
-program.command('dl <method>').alias('downloadstation').description('DSM Download Station API').option('-c, --config <path>', "DSM configuration file. Default to ~/" + CONFIG_DIR + "/" + CONFIG_FILE).option('-u, --url <url>', 'DSM URL. Default to https://admin:password@localhost:5001').option("-p, --payload <payload>", "JSON Payload").option('-P, --pretty', 'Pretty print JSON output').option('-d, --debug', 'Enabling Debugging Output').on('--help', function() {
+program.command('dl <method>').alias('downloadstation').description('DSM Download Station API').option('-c, --config <path>', "DSM configuration file. Default to ~/" + CONFIG_DIR + "/" + CONFIG_FILE).option('-u, --url <url>', 'DSM URL. Default to https://admin:password@localhost:5001').option("-p, --payload <payload>", "JSON Payload").option('-P, --pretty', 'Prettyprint JSON Output').option('-d, --debug', 'Enabling Debugging Output').on('--help', function() {
   console.log('  Examples:');
   console.log('');
   console.log('    $ syno dl listTasks');

--- a/bin/syno.js
+++ b/bin/syno.js
@@ -23,10 +23,10 @@ os = require('os');
 execute = function(api, cmd, options) {
   var exception, payload;
   if (program.debug) {
-    console.log("[DEBUG] : Method name : %s", cmd);
+    console.log("[DEBUG] : Method name configured : %s", cmd);
   }
   if (options.payload && program.debug) {
-    console.log("[DEBUG] : Method payload : %s", options.payload);
+    console.log("[DEBUG] : JSON payload configured : %s", options.payload);
   }
   if (options.pretty && program.debug) {
     console.log('[DEBUG] : Prettify output detected');
@@ -89,7 +89,7 @@ nconf.argv.env;
 
 if (program.url) {
   if (program.debug) {
-    console.log("[DEBUG] : Url detected : %s.", program.url);
+    console.log("[DEBUG] : Params URL detected : %s.", program.url);
   }
   url_resolved = url.parse(program.url);
   nconf.overrides({
@@ -124,7 +124,7 @@ if (program.url) {
 } else {
   if (!fs.existsSync(path.homedir() + ("/" + CONFIG_DIR))) {
     if (program.debug) {
-      console.log("[DEBUG] : %s doesn't exist", path.homedir() + ("/" + CONFIG_DIR));
+      console.log("[DEBUG] : Default configuration file doesn't exist : %s", path.homedir() + ("/" + CONFIG_DIR + "/" + CONFIG_FILE));
     }
     fs.mkdir(path.homedir() + ("/" + CONFIG_DIR), function(err) {
       if (err) {
@@ -136,14 +136,14 @@ if (program.url) {
         nconf.set('url:account', 'admin');
         nconf.set('url:passwd', 'password');
         if (program.debug) {
-          console.log("[DEBUG] : Save default configuration file to : %s", path.homedir() + ("/" + CONFIG_DIR + "/" + CONFIG_FILE));
+          console.log("[DEBUG] : Default configuration file created : %s", path.homedir() + ("/" + CONFIG_DIR + "/" + CONFIG_FILE));
         }
         return nconf.save();
       }
     });
   }
   if (program.debug) {
-    console.log("[DEBUG] : Load default config file : ~/" + CONFIG_DIR + "/" + CONFIG_FILE);
+    console.log("[DEBUG] : Default configuration file loaded : ~/" + CONFIG_DIR + "/" + CONFIG_FILE);
   }
   nconf.file({
     file: path.homedir() + ("/" + CONFIG_DIR + "/" + CONFIG_FILE),
@@ -169,7 +169,7 @@ nconf.defaults({
 });
 
 if (program.debug) {
-  console.log("[DEBUG] : Connection URL : %s://%s:%s@%s:%s", nconf.get('url:protocol'), nconf.get('url:account'), nconf.get('url:passwd'), nconf.get('url:host'), nconf.get('url:port'));
+  console.log("[DEBUG] : DSM Connection URL configured : %s://%s:%s@%s:%s", nconf.get('url:protocol'), nconf.get('url:account'), nconf.get('url:passwd'), nconf.get('url:host'), nconf.get('url:port'));
 }
 
 syno = new Syno({
@@ -188,7 +188,7 @@ program.command('fs <method>').alias('filestation').description('DSM File Statio
   return console.log('');
 }).action(function(cmd, options) {
   if (program.debug) {
-    console.log("[DEBUG] : DSM File Station API selected");
+    console.log("[DEBUG] : DSM File Station API command selected");
   }
   return execute('fs', cmd, options);
 });
@@ -202,7 +202,7 @@ program.command('dl <method>').alias('downloadstation').description('DSM Downloa
   return console.log('');
 }).action(function(cmd, options) {
   if (program.debug) {
-    console.log("[DEBUG] : DSM Download Station API selected");
+    console.log("[DEBUG] : DSM Download Station API command selected");
   }
   return execute('dl', cmd, options);
 });

--- a/bin/syno.js
+++ b/bin/syno.js
@@ -1,0 +1,194 @@
+var CONFIG_DIR, CONFIG_FILE, DEBUG, Syno, execute, fs, nconf, os, path, program, syno, url, url_resolved, yaml;
+
+DEBUG = true;
+
+CONFIG_DIR = '.syno';
+
+CONFIG_FILE = 'auth.yaml';
+
+program = require('commander');
+
+fs = require('fs');
+
+url = require('url');
+
+nconf = require('nconf');
+
+path = require('path-extra');
+
+yaml = require('js-yaml');
+
+Syno = require('../dist/syno.js');
+
+os = require('os');
+
+execute = function(api, cmd, options) {
+  var exception, payload;
+  if (DEBUG) {
+    console.log("[DEBUG] : Method name : %s", cmd);
+  }
+  if (options.payload && DEBUG) {
+    console.log("[DEBUG] : Method payload : %s", options.payload);
+  }
+  if (options.pretty && DEBUG) {
+    console.log('[DEBUG] : Prettify output detected');
+  }
+  try {
+    payload = JSON.parse(options.payload || '{}');
+  } catch (_error) {
+    exception = _error;
+    console.log("[ERROR] : JSON Exception : %s", exception);
+    process.exit(1);
+  }
+  return syno[api][cmd](payload, function(err, data) {
+    if (err) {
+      console.log("[ERROR] : %s", err);
+    }
+    if (options.pretty) {
+      data = JSON.stringify(data, void 0, 2);
+    } else {
+      data = JSON.stringify(data);
+    }
+    if (data) {
+      console.log(data);
+    }
+    return process.exit(0);
+  });
+};
+
+program.version('1.0.1').description('Synology Rest API Command Line').option('-c, --config <path>', "DSM Login Config file. defaults to ~/" + CONFIG_DIR + "/" + CONFIG_FILE).option('-u, --url <url>', 'DSM Uri - Default : (http://admin:password@localhost:5001)').on('--help', function() {
+  console.log('  Commands:');
+  console.log('');
+  console.log('    fs|filestation [options] <method>  DSM File Station API');
+  console.log('    dl|downloadstation [options] <method>  DSM Download Station API');
+  return console.log('');
+}).on('--help', function() {
+  console.log('  Examples:');
+  console.log('');
+  console.log('    $ syno fs getFileStationInfo');
+  console.log('    $ syno dl getDownloadStationInfo');
+  return console.log('');
+});
+
+program.parse(process.argv);
+
+if (program.args.length === 0 || (program.args.length > 0 && program.args[0] !== 'fs' && program.args[0] !== 'dl')) {
+  program.help();
+}
+
+nconf.argv.env;
+
+if (program.url) {
+  if (DEBUG) {
+    console.log("[DEBUG] : Url detected : %s.", program.url);
+  }
+  url_resolved = url.parse(program.url);
+  nconf.overrides({
+    auth: {
+      protocol: url_resolved.protocol.slice(0, -1),
+      host: url_resolved.hostname,
+      port: url_resolved.port,
+      account: url_resolved.auth.split(':')[0],
+      passwd: url_resolved.auth.split(':')[1]
+    }
+  });
+} else if (program.config) {
+  if (DEBUG) {
+    console.log("[DEBUG] : Load config file : %s.", program.config);
+  }
+  if (fs.existsSync(program.config)) {
+    nconf.file({
+      file: program.config,
+      format: {
+        stringify: function(obj, options) {
+          return yaml.safeDump(obj, options);
+        },
+        parse: function(obj, options) {
+          return yaml.safeLoad(obj, options);
+        }
+      }
+    });
+  } else {
+    console.log("[ERROR] : Config file : %s not found.", program.config);
+    process.exit(1);
+  }
+} else {
+  if (DEBUG) {
+    console.log("[DEBUG] : Load default config file : ~/" + CONFIG_DIR + "/auth.yaml.");
+  }
+  nconf.file({
+    file: path.homedir() + ("/" + CONFIG_DIR + "/" + CONFIG_FILE),
+    format: {
+      stringify: function(obj, options) {
+        return yaml.safeDump(obj, options);
+      },
+      parse: function(obj, options) {
+        return yaml.safeLoad(obj, options);
+      }
+    }
+  });
+}
+
+nconf.defaults({
+  auth: {
+    protocol: 'http',
+    host: 'localhost',
+    port: 5001,
+    account: 'admin',
+    passwd: 'password'
+  }
+});
+
+nconf.save(function(err) {
+  if (err && err.code === "ENOENT") {
+    fs.mkdir(path.homedir() + ("/" + CONFIG_DIR), function(err) {
+      if (err) {
+        return console.log;
+      } else {
+        nconf.set('auth:protocol', 'http');
+        nconf.set('auth:host', 'localhost');
+        nconf.set('auth:port', 5001);
+        nconf.set('auth:account', 'admin');
+        nconf.set('auth:passwd', 'password');
+        return nconf.save();
+      }
+    });
+  }
+});
+
+syno = new Syno({
+  protocol: nconf.get('auth:protocol'),
+  host: nconf.get('auth:host'),
+  port: nconf.get('auth:port'),
+  account: nconf.get('auth:account'),
+  passwd: nconf.get('auth:passwd')
+});
+
+program.command('fs <method>').alias('filestation').description('DSM File Station API').option('-c, --config <path>', "DSM Login Config file. defaults to ~/" + CONFIG_DIR + "/" + CONFIG_FILE).option('-u, --url <url>', 'DSM Uri - Default : (http://admin:password@localhost:5001)').option("-p, --payload <payload>", "JSON Payload").option('-P, --pretty', 'Pretty print JSON output').on('--help', function() {
+  console.log('  Examples:');
+  console.log('');
+  console.log('    $ syno fs listSharedFolders');
+  console.log('    $ syno fs listFiles --pretty --payload \'{"folder_path":"/path/to/folder"}\'');
+  return console.log('');
+}).action(function(cmd, options) {
+  if (DEBUG) {
+    console.log("[DEBUG] : DSM File Station API selected");
+  }
+  return execute('fs', cmd, options);
+});
+
+program.command('dl <method>').alias('downloadstation').description('DSM Download Station API').option('-c, --config <path>', "DSM Login Config file. defaults to ~/" + CONFIG_DIR + "/" + CONFIG_FILE).option('-u, --url <url>', 'DSM Uri - Default : (http://admin:password@localhost:5001)').option("-p, --payload <payload>", "JSON Payload").option('-P, --pretty', 'Pretty print JSON output').on('--help', function() {
+  console.log('  Examples:');
+  console.log('');
+  console.log('    $ syno dl listTasks');
+  console.log('    $ syno dl listTasks --payload \'{"limit":1}\'');
+  console.log('    $ syno dl getTasksInfo --pretty --payload \'{"id":"task_id"}\'');
+  return console.log('');
+}).action(function(cmd, options) {
+  if (DEBUG) {
+    console.log("[DEBUG] : DSM Download Station API selected");
+  }
+  return execute('dl', cmd, options);
+});
+
+program.parse(process.argv);

--- a/bin/syno.js
+++ b/bin/syno.js
@@ -50,6 +50,7 @@ execute = function(api, cmd, options) {
     if (data) {
       console.log(data);
     }
+    syno.auth.logout();
     return process.exit(0);
   });
 };

--- a/grunt/aliases.yaml
+++ b/grunt/aliases.yaml
@@ -5,6 +5,7 @@ default:
     - concat:syno
     - coffee:syno
     - concat:exports
+    - coffee:syno-cli
     - uglify:syno
     - clean:tmp
-    - nodeunit:all
+    # - nodeunit:all

--- a/grunt/aliases.yaml
+++ b/grunt/aliases.yaml
@@ -8,4 +8,16 @@ default:
     - coffee:syno-cli
     - uglify:syno
     - clean:tmp
+
+test:
+    - default
     - nodeunit:all
+    - shell:syno-cli
+    
+test-syno:
+    - default
+    - nodeunit:all
+    
+test-syno-cli:
+    - default
+    - shell:syno-cli

--- a/grunt/aliases.yaml
+++ b/grunt/aliases.yaml
@@ -8,4 +8,4 @@ default:
     - coffee:syno-cli
     - uglify:syno
     - clean:tmp
-    # - nodeunit:all
+    - nodeunit:all

--- a/grunt/coffee.yaml
+++ b/grunt/coffee.yaml
@@ -4,3 +4,8 @@ options:
 syno:
     src: tmp/concat/syno.coffee
     dest: tmp/coffee/syno.js
+    
+syno-cli:
+    src:
+      - src/cli/Syno.coffee
+    dest: bin/syno.js

--- a/grunt/nodeunit.yaml
+++ b/grunt/nodeunit.yaml
@@ -1,1 +1,1 @@
-all: ['test/*.coffee']
+all: ['test/syno/*.coffee']

--- a/grunt/shell.yaml
+++ b/grunt/shell.yaml
@@ -1,0 +1,2 @@
+syno-cli:
+  command: 'sh test/cli/syno.sh'

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "grunt-contrib-concat": "^0.5.0",
     "grunt-contrib-uglify": "^0.7.0",
     "grunt-contrib-nodeunit": "^0.4.1",
+    "grunt-shell": "^1.1.1",
     "grunt-nsgen": "^0.1.3",
     "grunt-wrap": "^0.3.0",
     "load-grunt-config": "^0.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "syno",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Simple Synology API wrapper for Auth, FileStation and DownloadStation.",
   "main": "dist/syno.js",
   "scripts": {
@@ -27,9 +27,14 @@
     "url": "https://github.com/jimrobs/syno/issues"
   },
   "homepage": "https://github.com/jimrobs/syno",
+  "bin" : { "syno": "bin/syno.js" },
   "dependencies": {
     "lodash": "^3.1.0",
-    "request": "^2.48.0"
+    "request": "^2.48.0",
+    "commander": "^2.6.0",
+    "nconf": "^0.7.1",
+    "js-yaml": "^3.2.6",
+    "path-extra": "^0.3.0"
   },
   "devDependencies": {
     "grunt": "^0.4.5",

--- a/src/cli/syno.coffee
+++ b/src/cli/syno.coffee
@@ -30,6 +30,7 @@ execute = (api, cmd, options) ->
       else
         data = JSON.stringify data
       console.log data if data
+      syno.auth.logout()
       process.exit 0
 
 program

--- a/src/cli/syno.coffee
+++ b/src/cli/syno.coffee
@@ -1,4 +1,4 @@
-#!/usr/bin/env
+#!/usr/bin/env node
 
 CONFIG_DIR = '.syno'
 CONFIG_FILE = 'config.yaml'
@@ -95,8 +95,24 @@ else if program.config
     console.log "[ERROR] : Config file : %s not found", program.config
     process.exit 1
 else
+  
+  # If directory doesn't exist | create directory and save the file
+  if !fs.existsSync path.homedir() + "/#{CONFIG_DIR}"
+    console.log "[DEBUG] : %s doesn't exist", path.homedir() + "/#{CONFIG_DIR}" if program.debug
+    fs.mkdir path.homedir() + "/#{CONFIG_DIR}", (err) ->
+      if err
+        console.log "[ERROR] : %s", err
+      else
+        nconf.set('url:protocol', 'https')
+        nconf.set('url:host', 'localhost')
+        nconf.set('url:port', 5001)
+        nconf.set('url:account', 'admin')
+        nconf.set('url:passwd', 'password')
+        console.log "[DEBUG] : Save default configuration file to : %s", path.homedir() + "/#{CONFIG_DIR}/#{CONFIG_FILE}" if program.debug
+        nconf.save()
+  
+  # Load a yaml file using YAML formatter
   console.log "[DEBUG] : Load default config file : ~/#{CONFIG_DIR}/#{CONFIG_FILE}" if program.debug
-  # load a yaml file using a custom formatter
   nconf.file
     file: path.homedir() + "/#{CONFIG_DIR}/#{CONFIG_FILE}"
     format:
@@ -112,21 +128,6 @@ nconf.defaults
     port : 5001
     account : 'admin'
     passwd : 'password'
-
-# If directory doesn't exist | create and save
-if !fs.existsSync path.homedir() + "/#{CONFIG_DIR}"
-  console.log "[DEBUG] : %s doesn't exist", path.homedir() + "/#{CONFIG_DIR}" if program.debug
-  fs.mkdir path.homedir() + "/#{CONFIG_DIR}", (err) ->
-    if err
-      console.log "[ERROR] : %s", err
-    else
-      nconf.set('url:protocol', 'https')
-      nconf.set('url:host', 'localhost')
-      nconf.set('url:port', 5001)
-      nconf.set('url:account', 'admin')
-      nconf.set('url:passwd', 'password')
-      console.log "[DEBUG] : Save default configuration file to : %s", path.homedir() + "/#{CONFIG_DIR}/#{CONFIG_FILE}" if program.debug
-      nconf.save()
 
 console.log "[DEBUG] : Connection URL : %s://%s:%s@%s:%s", nconf.get('url:protocol'), nconf.get('url:account'), nconf.get('url:passwd'), nconf.get('url:host'), nconf.get('url:port') if program.debug
 syno = new Syno(

--- a/src/cli/syno.coffee
+++ b/src/cli/syno.coffee
@@ -1,6 +1,5 @@
 #!/usr/bin/env
 
-DEBUG = true
 CONFIG_DIR = '.syno'
 CONFIG_FILE = 'auth.yaml'
 
@@ -14,9 +13,9 @@ Syno = require('../dist/syno.js')
 os = require('os')
 
 execute = (api, cmd, options) ->
-    console.log "[DEBUG] : Method name : %s", cmd if DEBUG
-    console.log "[DEBUG] : Method payload : %s", options.payload if options.payload and DEBUG
-    console.log '[DEBUG] : Prettify output detected' if options.pretty and DEBUG
+    console.log "[DEBUG] : Method name : %s", cmd if program.debug
+    console.log "[DEBUG] : Method payload : %s", options.payload if options.payload and program.debug
+    console.log '[DEBUG] : Prettify output detected' if options.pretty and program.debug
     
     try
       payload = JSON.parse(options.payload || '{}')
@@ -38,6 +37,7 @@ program
 .description('Synology Rest API Command Line') 
 .option('-c, --config <path>', "DSM Login Config file. defaults to ~/#{CONFIG_DIR}/#{CONFIG_FILE}")
 .option('-u, --url <url>', 'DSM Uri - Default : (http://admin:password@localhost:5001)')
+.option('-d, --debug', 'Enabling Debugging Output')
 .on '--help', ->
   console.log '  Commands:'
   console.log ''
@@ -70,7 +70,7 @@ else if (program.args.length > 0 and program.args[0] != 'fs' and program.args[0]
 nconf.argv.env
 
 if program.url
-  console.log "[DEBUG] : Url detected : %s.", program.url if DEBUG
+  console.log "[DEBUG] : Url detected : %s.", program.url if program.debug
   url_resolved = url.parse program.url
   nconf.overrides
     auth:
@@ -80,7 +80,7 @@ if program.url
       account: url_resolved.auth.split(':')[0]
       passwd: url_resolved.auth.split(':')[1]
 else if program.config
-  console.log "[DEBUG] : Load config file : %s.", program.config if DEBUG
+  console.log "[DEBUG] : Load config file : %s.", program.config if program.debug
   # load a yaml file specified in config
   if fs.existsSync(program.config)
       nconf.file
@@ -94,7 +94,7 @@ else if program.config
     console.log "[ERROR] : Config file : %s not found.", program.config
     process.exit 1
 else
-  console.log "[DEBUG] : Load default config file : ~/#{CONFIG_DIR}/auth.yaml." if DEBUG
+  console.log "[DEBUG] : Load default config file : ~/#{CONFIG_DIR}/auth.yaml." if program.debug
   # load a yaml file using a custom formatter
   nconf.file
     file: path.homedir() + "/#{CONFIG_DIR}/#{CONFIG_FILE}"
@@ -114,7 +114,7 @@ nconf.defaults
 
 # If directory not exist | create and try again
 if !fs.existsSync path.homedir() + "/#{CONFIG_DIR}"
-  console.log "[DEBUG] : %s doesn't exist", path.homedir() + "/#{CONFIG_DIR}" if DEBUG
+  console.log "[DEBUG] : %s doesn't exist", path.homedir() + "/#{CONFIG_DIR}" if program.debug
   fs.mkdir path.homedir() + "/#{CONFIG_DIR}", (err) ->
     if err
       console.log err 
@@ -124,7 +124,7 @@ if !fs.existsSync path.homedir() + "/#{CONFIG_DIR}"
       nconf.set('auth:port', 5001)
       nconf.set('auth:account', 'admin')
       nconf.set('auth:passwd', 'password')
-      console.log "[DEBUG] : Save default config file to : %s", path.homedir() + "/#{CONFIG_DIR}" if DEBUG
+      console.log "[DEBUG] : Save default config file to : %s", path.homedir() + "/#{CONFIG_DIR}" if program.debug
       nconf.save()
 
 syno = new Syno(
@@ -142,6 +142,7 @@ program
 .option('-u, --url <url>', 'DSM Uri - Default : (http://admin:password@localhost:5001)')
 .option("-p, --payload <payload>", "JSON Payload")
 .option('-P, --pretty', 'Pretty print JSON output')
+.option('-d, --debug', 'Enabling Debugging Output')
 .on '--help', ->
   console.log '  Examples:'
   console.log ''
@@ -149,7 +150,7 @@ program
   console.log '    $ syno fs listFiles --pretty --payload \'{"folder_path":"/path/to/folder"}\''
   console.log ''
 .action (cmd, options) ->
-  console.log "[DEBUG] : DSM File Station API selected" if DEBUG
+  console.log "[DEBUG] : DSM File Station API selected" if program.debug
   execute 'fs', cmd, options
 
 program
@@ -160,6 +161,7 @@ program
 .option('-u, --url <url>', 'DSM Uri - Default : (http://admin:password@localhost:5001)')
 .option("-p, --payload <payload>", "JSON Payload")
 .option('-P, --pretty', 'Pretty print JSON output')
+.option('-d, --debug', 'Enabling Debugging Output')
 .on '--help', ->
   console.log '  Examples:'
   console.log ''
@@ -168,7 +170,7 @@ program
   console.log '    $ syno dl getTasksInfo --pretty --payload \'{"id":"task_id"}\''
   console.log ''
 .action (cmd, options) ->
-  console.log "[DEBUG] : DSM Download Station API selected" if DEBUG
+  console.log "[DEBUG] : DSM Download Station API selected" if program.debug
   execute 'dl', cmd, options
   
 program.parse process.argv

--- a/src/cli/syno.coffee
+++ b/src/cli/syno.coffee
@@ -13,8 +13,8 @@ Syno = require('../dist/syno.js')
 os = require('os')
 
 execute = (api, cmd, options) ->
-    console.log "[DEBUG] : Method name : %s", cmd if program.debug
-    console.log "[DEBUG] : Method payload : %s", options.payload if options.payload and program.debug
+    console.log "[DEBUG] : Method name configured : %s", cmd if program.debug
+    console.log "[DEBUG] : JSON payload configured : %s", options.payload if options.payload and program.debug
     console.log '[DEBUG] : Prettify output detected' if options.pretty and program.debug
     
     try
@@ -71,7 +71,7 @@ else if (program.args.length > 0 and program.args[0] != 'fs' and program.args[0]
 nconf.argv.env
 
 if program.url
-  console.log "[DEBUG] : Url detected : %s.", program.url if program.debug
+  console.log "[DEBUG] : Params URL detected : %s.", program.url if program.debug
   url_resolved = url.parse program.url
   nconf.overrides
     url:
@@ -98,7 +98,7 @@ else
   
   # If directory doesn't exist | create directory and save the file
   if !fs.existsSync path.homedir() + "/#{CONFIG_DIR}"
-    console.log "[DEBUG] : %s doesn't exist", path.homedir() + "/#{CONFIG_DIR}" if program.debug
+    console.log "[DEBUG] : Default configuration file doesn't exist : %s", path.homedir() + "/#{CONFIG_DIR}/#{CONFIG_FILE}" if program.debug
     fs.mkdir path.homedir() + "/#{CONFIG_DIR}", (err) ->
       if err
         console.log "[ERROR] : %s", err
@@ -108,11 +108,11 @@ else
         nconf.set('url:port', 5001)
         nconf.set('url:account', 'admin')
         nconf.set('url:passwd', 'password')
-        console.log "[DEBUG] : Save default configuration file to : %s", path.homedir() + "/#{CONFIG_DIR}/#{CONFIG_FILE}" if program.debug
+        console.log "[DEBUG] : Default configuration file created : %s", path.homedir() + "/#{CONFIG_DIR}/#{CONFIG_FILE}" if program.debug
         nconf.save()
   
   # Load a yaml file using YAML formatter
-  console.log "[DEBUG] : Load default config file : ~/#{CONFIG_DIR}/#{CONFIG_FILE}" if program.debug
+  console.log "[DEBUG] : Default configuration file loaded : ~/#{CONFIG_DIR}/#{CONFIG_FILE}" if program.debug
   nconf.file
     file: path.homedir() + "/#{CONFIG_DIR}/#{CONFIG_FILE}"
     format:
@@ -129,7 +129,7 @@ nconf.defaults
     account : 'admin'
     passwd : 'password'
 
-console.log "[DEBUG] : Connection URL : %s://%s:%s@%s:%s", nconf.get('url:protocol'), nconf.get('url:account'), nconf.get('url:passwd'), nconf.get('url:host'), nconf.get('url:port') if program.debug
+console.log "[DEBUG] : DSM Connection URL configured : %s://%s:%s@%s:%s", nconf.get('url:protocol'), nconf.get('url:account'), nconf.get('url:passwd'), nconf.get('url:host'), nconf.get('url:port') if program.debug
 syno = new Syno(
   protocol: nconf.get('url:protocol')
   host: nconf.get('url:host')
@@ -153,7 +153,7 @@ program
   console.log '    $ syno fs listFiles --pretty --payload \'{"folder_path":"/path/to/folder"}\''
   console.log ''
 .action (cmd, options) ->
-  console.log "[DEBUG] : DSM File Station API selected" if program.debug
+  console.log "[DEBUG] : DSM File Station API command selected" if program.debug
   execute 'fs', cmd, options
 
 program
@@ -173,7 +173,7 @@ program
   console.log '    $ syno dl getTasksInfo --pretty --payload \'{"id":"task_id"}\''
   console.log ''
 .action (cmd, options) ->
-  console.log "[DEBUG] : DSM Download Station API selected" if program.debug
+  console.log "[DEBUG] : DSM Download Station API command selected" if program.debug
   execute 'dl', cmd, options
   
 program.parse process.argv

--- a/src/cli/syno.coffee
+++ b/src/cli/syno.coffee
@@ -1,0 +1,162 @@
+#!/usr/bin/env
+
+DEBUG = true
+CONFIG_DIR = '.syno'
+CONFIG_FILE = 'auth.yaml'
+
+program = require('commander')
+fs = require('fs')
+url = require('url')
+nconf = require('nconf')
+path = require('path-extra');
+yaml = require('js-yaml');
+Syno = require('../dist/syno.js')
+os = require('os')
+
+execute = (api, cmd, options) ->
+    console.log "[DEBUG] : Method name : %s", cmd if DEBUG
+    console.log "[DEBUG] : Method payload : %s", options.payload if options.payload and DEBUG
+    console.log '[DEBUG] : Prettify output detected' if options.pretty and DEBUG
+    
+    try
+      payload = JSON.parse(options.payload || '{}')
+    catch exception
+      console.log "[ERROR] : JSON Exception : %s", exception
+      process.exit 1
+    
+    syno[api][cmd] payload, (err, data) ->
+      console.log "[ERROR] : %s", err if err
+      if options.pretty
+        data = JSON.stringify data, undefined, 2
+      else
+        data = JSON.stringify data
+      console.log data if data
+      process.exit 0
+
+program
+.version('1.0.1')
+.description('Synology Rest API Command Line') 
+.option('-c, --config <path>', "DSM Login Config file. defaults to ~/#{CONFIG_DIR}/#{CONFIG_FILE}")
+.option('-u, --url <url>', 'DSM Uri - Default : (http://admin:password@localhost:5001)')
+.on '--help', ->
+  console.log '  Commands:'
+  console.log ''
+  console.log '    fs|filestation [options] <method>  DSM File Station API'
+  console.log '    dl|downloadstation [options] <method>  DSM Download Station API'
+  console.log ''
+.on '--help', ->
+  console.log '  Examples:'
+  console.log ''
+  console.log '    $ syno fs getFileStationInfo'
+  console.log '    $ syno dl getDownloadStationInfo'
+  console.log ''
+
+program.parse process.argv
+program.help() if program.args.length == 0 or (program.args.length > 0 and program.args[0] != 'fs' and program.args[0] != 'dl') #fs or ds required
+
+# load cmd line args and environment vars
+nconf.argv.env
+
+if program.url
+  console.log "[DEBUG] : Url detected : %s.", program.url if DEBUG
+  url_resolved = url.parse program.url
+  nconf.overrides
+    auth:
+      protocol: url_resolved.protocol.slice(0,-1)
+      host: url_resolved.hostname
+      port: url_resolved.port
+      account: url_resolved.auth.split(':')[0]
+      passwd: url_resolved.auth.split(':')[1]
+else if program.config
+  console.log "[DEBUG] : Load config file : %s.", program.config if DEBUG
+  # load a yaml file specified in config
+  if fs.existsSync(program.config)
+      nconf.file
+        file: program.config
+        format:
+          stringify: (obj, options) ->
+            yaml.safeDump obj, options
+          parse: (obj, options) ->
+            yaml.safeLoad obj, options
+  else
+    console.log "[ERROR] : Config file : %s not found.", program.config
+    process.exit 1
+else
+  console.log "[DEBUG] : Load default config file : ~/#{CONFIG_DIR}/auth.yaml." if DEBUG
+  # load a yaml file using a custom formatter
+  nconf.file
+    file: path.homedir() + "/#{CONFIG_DIR}/#{CONFIG_FILE}"
+    format:
+      stringify: (obj, options) ->
+        yaml.safeDump obj, options
+      parse: (obj, options) ->
+        yaml.safeLoad obj, options
+    
+nconf.defaults
+  auth:
+    protocol: 'http'
+    host : 'localhost'
+    port : 5001
+    account : 'admin'
+    passwd : 'password'
+
+nconf.save (err) ->
+  # If directory not exist | create and try again
+  if err and err.code == "ENOENT"
+    fs.mkdir path.homedir() + "/#{CONFIG_DIR}", (err) ->
+      if err
+        console.log
+      else
+        nconf.set('auth:protocol', 'http')
+        nconf.set('auth:host', 'localhost')
+        nconf.set('auth:port', 5001)
+        nconf.set('auth:account', 'admin')
+        nconf.set('auth:passwd', 'password')
+        nconf.save()
+  return
+
+syno = new Syno(
+  protocol: nconf.get('auth:protocol')
+  host: nconf.get('auth:host')
+  port: nconf.get('auth:port')
+  account: nconf.get('auth:account')
+  passwd: nconf.get('auth:passwd'))
+  
+program
+.command('fs <method>')
+.alias('filestation')
+.description('DSM File Station API')
+.option('-c, --config <path>', "DSM Login Config file. defaults to ~/#{CONFIG_DIR}/#{CONFIG_FILE}")
+.option('-u, --url <url>', 'DSM Uri - Default : (http://admin:password@localhost:5001)')
+.option("-p, --payload <payload>", "JSON Payload")
+.option('-P, --pretty', 'Pretty print JSON output')
+.on '--help', ->
+  console.log '  Examples:'
+  console.log ''
+  console.log '    $ syno fs listSharedFolders'
+  console.log '    $ syno fs listFiles --pretty --payload \'{"folder_path":"/path/to/folder"}\''
+  console.log ''
+.action (cmd, options) ->
+  console.log "[DEBUG] : DSM File Station API selected" if DEBUG
+  execute 'fs', cmd, options
+
+program
+.command('dl <method>')
+.alias('downloadstation')
+.description('DSM Download Station API')
+.option('-c, --config <path>', "DSM Login Config file. defaults to ~/#{CONFIG_DIR}/#{CONFIG_FILE}")
+.option('-u, --url <url>', 'DSM Uri - Default : (http://admin:password@localhost:5001)')
+.option("-p, --payload <payload>", "JSON Payload")
+.option('-P, --pretty', 'Pretty print JSON output')
+.on '--help', ->
+  console.log '  Examples:'
+  console.log ''
+  console.log '    $ syno dl listTasks'
+  console.log '    $ syno dl listTasks --payload \'{"limit":1}\''
+  console.log '    $ syno dl getTasksInfo --pretty --payload \'{"id":"task_id"}\''
+  console.log ''
+.action (cmd, options) ->
+  console.log "[DEBUG] : DSM Download Station API selected" if DEBUG
+  execute 'dl', cmd, options
+  
+program.parse process.argv

--- a/src/cli/syno.coffee
+++ b/src/cli/syno.coffee
@@ -52,7 +52,19 @@ program
   console.log ''
 
 program.parse process.argv
-program.help() if program.args.length == 0 or (program.args.length > 0 and program.args[0] != 'fs' and program.args[0] != 'dl') #fs or ds required
+
+if program.args.length == 0
+  program.help()
+else if (program.args.length > 0 and program.args[0] != 'fs' and program.args[0] != 'dl')
+  console.log ''
+  console.log "  [ERROR] : #{program.args[0]} is not a valid command !"
+  console.log ''
+  console.log '  Examples:'
+  console.log ''
+  console.log '    $ syno fs <method> DSM File Station API'
+  console.log '    $ syno dl <method> DSM Download Station API'
+  console.log ''
+  process.exit 1
 
 # load cmd line args and environment vars
 nconf.argv.env
@@ -100,20 +112,20 @@ nconf.defaults
     account : 'admin'
     passwd : 'password'
 
-nconf.save (err) ->
-  # If directory not exist | create and try again
-  if err and err.code == "ENOENT"
-    fs.mkdir path.homedir() + "/#{CONFIG_DIR}", (err) ->
-      if err
-        console.log
-      else
-        nconf.set('auth:protocol', 'http')
-        nconf.set('auth:host', 'localhost')
-        nconf.set('auth:port', 5001)
-        nconf.set('auth:account', 'admin')
-        nconf.set('auth:passwd', 'password')
-        nconf.save()
-  return
+# If directory not exist | create and try again
+if !fs.existsSync path.homedir() + "/#{CONFIG_DIR}"
+  console.log "[DEBUG] : %s doesn't exist", path.homedir() + "/#{CONFIG_DIR}" if DEBUG
+  fs.mkdir path.homedir() + "/#{CONFIG_DIR}", (err) ->
+    if err
+      console.log err 
+    else
+      nconf.set('auth:protocol', 'http')
+      nconf.set('auth:host', 'localhost')
+      nconf.set('auth:port', 5001)
+      nconf.set('auth:account', 'admin')
+      nconf.set('auth:passwd', 'password')
+      console.log "[DEBUG] : Save default config file to : %s", path.homedir() + "/#{CONFIG_DIR}" if DEBUG
+      nconf.save()
 
 syno = new Syno(
   protocol: nconf.get('auth:protocol')

--- a/test/cli/syno.sh
+++ b/test/cli/syno.sh
@@ -2,11 +2,11 @@
 
 URL="https://admin:synology@demo.synology.com:5001"
 
-node ../../bin/syno.js fs getFileStationInfo -u $URL -d
-node ../../bin/syno.js dl getDownloadStationInfo -u $URL -d
-node ../../bin/syno.js fs listSharedFolders -u $URL -d
-node ../../bin/syno.js fs listFiles -p '{"folder_path":"/photo"}' -u $URL -d
-node ../../bin/syno.js fs listFiles -p '{"folder_path":"/photo"}' -u $URL -P -d
-node ../../bin/syno.js dl listTasks -u $URL -d
-node ../../bin/syno.js dl listTasks -p '{"limit":0}' -u $URL -d
-node ../../bin/syno.js dl getStats -u $URL -d
+node bin/syno.js fs getFileStationInfo -u $URL -d
+node bin/syno.js dl getDownloadStationInfo -u $URL -d
+node bin/syno.js fs listSharedFolders -u $URL -d
+node bin/syno.js fs listFiles -p '{"folder_path":"/photo"}' -u $URL -d
+node bin/syno.js fs listFiles -p '{"folder_path":"/photo"}' -u $URL -P -d
+node bin/syno.js dl listTasks -u $URL -d
+node bin/syno.js dl listTasks -p '{"limit":0}' -u $URL -d
+node bin/syno.js dl getStats -u $URL -d

--- a/test/cli/syno.sh
+++ b/test/cli/syno.sh
@@ -2,10 +2,11 @@
 
 URL="https://admin:synology@demo.synology.com:5001"
 
-node ../../bin/syno.js fs getFileStationInfo -u $URL
-node ../../bin/syno.js dl getDownloadStationInfo -u $URL
-node ../../bin/syno.js fs listSharedFolders -u $URL
-node ../../bin/syno.js fs listFiles -p '{"folder_path":"/photo"}' -u $URL
-node ../../bin/syno.js fs listFiles -p '{"folder_path":"/photo"}' -u $URL -P
-node ../../bin/syno.js dl listTasks -u $URL
-node ../../bin/syno.js dl listTasks -p '{"limit":0}' -u $URL
+node ../../bin/syno.js fs getFileStationInfo -u $URL -d
+node ../../bin/syno.js dl getDownloadStationInfo -u $URL -d
+node ../../bin/syno.js fs listSharedFolders -u $URL -d
+node ../../bin/syno.js fs listFiles -p '{"folder_path":"/photo"}' -u $URL -d
+node ../../bin/syno.js fs listFiles -p '{"folder_path":"/photo"}' -u $URL -P -d
+node ../../bin/syno.js dl listTasks -u $URL -d
+node ../../bin/syno.js dl listTasks -p '{"limit":0}' -u $URL -d
+node ../../bin/syno.js dl getStats -u $URL -d

--- a/test/cli/syno.sh
+++ b/test/cli/syno.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+URL="https://admin:synology@demo.synology.com:5001"
+
+node ../../bin/syno.js fs getFileStationInfo -u $URL
+node ../../bin/syno.js dl getDownloadStationInfo -u $URL
+node ../../bin/syno.js fs listSharedFolders -u $URL
+node ../../bin/syno.js fs listFiles -p '{"folder_path":"/photo"}' -u $URL
+node ../../bin/syno.js fs listFiles -p '{"folder_path":"/photo"}' -u $URL -P
+node ../../bin/syno.js dl listTasks -u $URL
+node ../../bin/syno.js dl listTasks -p '{"limit":0}' -u $URL

--- a/test/syno/Auth.coffee
+++ b/test/syno/Auth.coffee
@@ -1,4 +1,4 @@
-Syno = require('../dist/syno.js')
+Syno = require('../../dist/syno.js')
 
 synoWithValidCredentials = new Syno(
   protocol: 'https'

--- a/test/syno/DownloadStation.coffee
+++ b/test/syno/DownloadStation.coffee
@@ -1,4 +1,4 @@
-Syno = require('../dist/syno.js')
+Syno = require('../../dist/syno.js')
 
 module.exports =
   


### PR DESCRIPTION
# Command Line Support

- [x] Read default configuration file (~/.syno/config.yaml).
- [x] Read another configuration file specified via -c (--config) flag
- [x] Read url via -u (--url) flag. Default to https://admin:password@localhost:5001
- [x] Debug flag via -d (--debug)
- [x] Pretty Print Output JSON via -P (--pretty)
- [ ] [Download/Upload File Support](https://github.com/JimRobs/syno#download-filefolders-from-file-station).

## Usages

```
$ syno --help
Usage: syno [options]

  Synology Rest API Command Line

  Options:

    -h, --help           output usage information
    -V, --version        output the version number

  Commands:

    fs|filestation [options] <method>  DSM File Station API
    dl|downloadstation [options] <method>  DSM Download Station API

  Examples:

    $ syno fs getFileStationInfo
    $ syno dl getDownloadStationInfo
```

```
$ syno fs --help
Usage: fs|filestation [options] <method>

  DSM File Station API

  Options:

    -h, --help               output usage information
    -c, --config <path>      DSM Login Config file. Default to ~/.syno/config.yaml
    -u, --url <url>          DSM URL - Default to https://admin:password@localhost:5001
    -p, --payload <payload>  JSON Payload
    -P, --pretty             Prettyprint JSON Output
    -d, --debug              Enabling Debugging Output

  Examples:

    $ syno fs listSharedFolders
    $ syno fs listFiles --pretty --payload '{"folder_path":"/path/to/folder"}'
```

```
$ syno ds --help
Usage: dl|downloadstation [options] <method>

  DSM Download Station API

  Options:

    -h, --help               output usage information
    -c, --config <path>      DSM Login Config file. Default to ~/.syno/config.yaml
    -u, --url <url>          DSM URL - Default to https://admin:password@localhost:5001
    -p, --payload <payload>  JSON Payload
    -P, --pretty             Prettyprint JSON Output
    -d, --debug              Enabling Debugging Output

  Examples:

    $ syno dl listTasks
    $ syno dl listTasks --payload '{"limit":1}'
    $ syno dl getTasksInfo --pretty --payload '{"id":"task_id"}'
```

## Examples

### Without a configuration file

```bash
$ URL="https://admin:synology@demo.synology.com:5001"
$
$ syno fs getFileStationInfo -u $URL -d
$ syno dl getDownloadStationInfo -u $URL -d
$ syno fs listSharedFolders -u $URL -d
$ syno fs listFiles -p '{"folder_path":"/photo"}' -u $URL -d
$ syno fs listFiles -p '{"folder_path":"/photo"}' -u $URL -P -d
$ syno dl listTasks -u $URL -d
$ syno dl listTasks -p '{"limit":0}' -u $URL -d
$ syno dl getStats -u $URL -d%
```

### With a configuration file

```yaml
# Example config file, by default it should be located at:
# ~/.syno/config.conf

url:
  protocol: http
  host: localhost
  port: 5001
  account: admin
  passwd: password
```

```bash
$ syno fs getFileStationInfo
```